### PR TITLE
Improve HTTP error handling - Return details instead of just the title

### DIFF
--- a/nlpsandboxclient/utils.py
+++ b/nlpsandboxclient/utils.py
@@ -10,7 +10,7 @@ def _raise_for_status(response):
     Catches and wraps NLP HTTP errors with appropriate text.
     """
     if response.status_code not in [200, 201, 202]:
-        raise HTTPError(response.json()['title'], response)
+        raise HTTPError(response.json()['detail'], response)
 
 
 def stdout_or_json(json_dict: dict, output: str):


### PR DESCRIPTION
fixes #63 .  This returns something like


```
HTTPError: [Errno Tried to save duplicate unique keys (E11000 duplicate key error collection: nlpsandbox.dataset index: name_1 dup key: { name: "datasets/awesome-dataset" }, full error: {'index': 0, 'code': 11000, 'keyPattern': {'name': 1}, 'keyValue': {'name': 'datasets/awesome-dataset'}, 'errmsg': 'E11000 duplicate key error collection: nlpsandbox.dataset index: name_1 dup key: { name: "datasets/awesome-dataset" }'})] <Response [409]>
```

This seems very verbose though.  The `details` that are returned seems to be in a weird format...