### PR TITLE
Evaluation should still happen for date and person

### DIFF
--- a/nlpsandboxclient/evaluation.py
+++ b/nlpsandboxclient/evaluation.py
@@ -203,11 +203,6 @@ class Evaluation(metaclass=ABCMeta):
         self.print_out(tp, fp, fn, "token", "strict")
 
     def print_out(self, tp, fp, fn, type_up, type_lower):
-        # if self.evaluation_type == "date" or self.evaluation_type == "person":
-        #     precision = float('nan')
-        #     recall = float('nan')
-        #     F1 = float('nan')
-        # else:
         # precision (P): TP / (TP + FP)
         # Recall (R): TP / (TP + FN)
         # F1 score: 2 * ((P * R) / (P + R))

--- a/nlpsandboxclient/evaluation.py
+++ b/nlpsandboxclient/evaluation.py
@@ -203,20 +203,20 @@ class Evaluation(metaclass=ABCMeta):
         self.print_out(tp, fp, fn, "token", "strict")
 
     def print_out(self, tp, fp, fn, type_up, type_lower):
-        if self.evaluation_type == "date" or self.evaluation_type == "person":
-            precision = float('nan')
-            recall = float('nan')
-            F1 = float('nan')
+        # if self.evaluation_type == "date" or self.evaluation_type == "person":
+        #     precision = float('nan')
+        #     recall = float('nan')
+        #     F1 = float('nan')
+        # else:
+        # precision (P): TP / (TP + FP)
+        # Recall (R): TP / (TP + FN)
+        # F1 score: 2 * ((P * R) / (P + R))
+        precision = round(tp / (tp + fp), 2)
+        recall = round(tp / (tp + fn), 2)
+        if precision + recall == 0:
+            F1 = 0
         else:
-            # precision (P): TP / (TP + FP)
-            # Recall (R): TP / (TP + FN)
-            # F1 score: 2 * ((P * R) / (P + R))
-            precision = round(tp / (tp + fp), 2)
-            recall = round(tp / (tp + fn), 2)
-            if precision + recall == 0:
-                F1 = 0
-            else:
-                F1 = round(2 * ((precision * recall) / (precision + recall)), 2)
+            F1 = round(2 * ((precision * recall) / (precision + recall)), 2)
         # print("F1 {}".format(F1))
         # print(type_up,type_lower)
         # print("tp: {},fp: {},fn: {}".format(tp,fp,fn))
@@ -243,8 +243,12 @@ class Evaluation(metaclass=ABCMeta):
                 self.loc_list.append(loc_map)
         else:
             for key in eval_dict.keys():
+                value = eval_dict[key]
+                # first hard code not returning scores for dateFormat and personType
+                if self.evaluation_type == "date" or self.evaluation_type == "person":
+                    value = float('nan')
                 type_map = {"metric": key,
-                            "value": eval_dict[key]}
+                            "value": value}
                 self.type_list.append(type_map)
 
 


### PR DESCRIPTION
I should have looked closer but the evaluation patch that was done actually made all scores NA for date and person.  Can you check that this fix is ok @yy6linda ?

We only want the type scores to be NA, not all the scores.