### PR TITLE
Rename CLI modules

### DIFF
--- a/.github/workflows/sphinx-ghpages.yaml
+++ b/.github/workflows/sphinx-ghpages.yaml
@@ -1,8 +1,8 @@
 name: "Pull Request Docs Check"
 on: 
   push:
-    branches:
-      - develop
+    tags:
+      - '*.*.*'
 jobs:
   docs:
     runs-on: ubuntu-latest

--- a/nlpsandboxclient/cli/__main__.py
+++ b/nlpsandboxclient/cli/__main__.py
@@ -2,7 +2,7 @@
 import click
 
 from .. import __version__
-from . import community, evaluate
+from . import annotator_cli, community, datanode_cli, evaluate
 
 
 @click.group()
@@ -13,5 +13,7 @@ def cli():
 
 def main():
     cli.add_command(community.cli)
-    cli.add_command(evaluate.cli)
+    cli.add_command(evaluate.evaluate_prediction)
+    cli.add_command(datanode_cli.cli)
+    cli.add_command(annotator_cli.cli)
     cli()

--- a/nlpsandboxclient/cli/__main__.py
+++ b/nlpsandboxclient/cli/__main__.py
@@ -2,7 +2,7 @@
 import click
 
 from .. import __version__
-from . import annotator_cli, community, datanode_cli, evaluate
+from . import community, datanode_cli, evaluate, tool
 
 
 @click.group()
@@ -15,5 +15,5 @@ def main():
     cli.add_command(community.cli)
     cli.add_command(evaluate.evaluate_prediction)
     cli.add_command(datanode_cli.cli)
-    cli.add_command(annotator_cli.cli)
+    cli.add_command(tool.cli)
     cli()

--- a/nlpsandboxclient/cli/annotator_cli.py
+++ b/nlpsandboxclient/cli/annotator_cli.py
@@ -7,7 +7,7 @@ from nlpsandboxclient import client, utils
 
 @click.group(name='annotator', no_args_is_help=True)
 def cli():
-    """Commands to interact with NLP annotators"""
+    """Commands to interact with NLP annotators."""
 
 
 @cli.command(no_args_is_help=True)

--- a/nlpsandboxclient/cli/annotator_cli.py
+++ b/nlpsandboxclient/cli/annotator_cli.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+import json
+
+import click
+from nlpsandboxclient import client, utils
+
+
+@click.group(name='annotator', no_args_is_help=True)
+def cli():
+    """Commands to interact with NLP annotators"""
+
+
+@cli.command(no_args_is_help=True)
+@click.option('--annotator_host', help='Annotator host.', required=True)
+@click.option('--note_json', help='Clinical notes json',
+              type=click.Path(exists=True), required=True)
+@click.option('--output', help='Specify output json path',
+              type=click.Path())
+@click.option('--annotator_type', help='Type of annotator.',
+              type=click.Choice(['date', 'person', 'address'],
+                                case_sensitive=False), required=True)
+def annotate_note(annotator_host, note_json, output, annotator_type):
+    """Annotate a note with specified annotator"""
+    with open(note_json, "r") as note_f:
+        notes = json.load(note_f)
+    all_annotations = []
+    for note in notes:
+        note_name = note.pop("note_name")
+        annotations = client.annotate_note(host=annotator_host,
+                                           note={"note": note},
+                                           annotator_type=annotator_type)
+        annotations['annotationSource'] = {
+            "resourceSource": {
+                "name": note_name
+            }
+        }
+        all_annotations.append(annotations)
+    utils.stdout_or_json(all_annotations, output)
+
+
+@cli.command(no_args_is_help=True)
+@click.option('--annotator_host', help='Annotator host', required=True)
+@click.option('--output', help='Specify output json path',
+              type=click.Path())
+def get_tool(annotator_host, output):
+    """Get annotator tool endpoint"""
+    tool = client.get_tool(host=annotator_host)
+    utils.stdout_or_json(tool.to_dict(), output)
+
+
+@cli.command(no_args_is_help=True)
+@click.option('--url', help='The url to check', required=True)
+def check_url(url):
+    """Checks if URL is implemented"""
+    utils.check_url(url=url)
+
+
+if __name__ == '__main__':
+    cli()

--- a/nlpsandboxclient/cli/community.py
+++ b/nlpsandboxclient/cli/community.py
@@ -7,7 +7,7 @@ from nlpsandboxclient import utils
 # Command Group
 @click.group(name='community', no_args_is_help=True)
 def cli():
-    """Commands for NLP Sandbox users"""
+    """Commands for NLP Sandbox users."""
 
 
 @cli.command()

--- a/nlpsandboxclient/cli/community.py
+++ b/nlpsandboxclient/cli/community.py
@@ -1,16 +1,13 @@
 #!/usr/bin/env python3
-import json
-
 import click
 
-from nlpsandboxclient import client, utils
-from nlpsandboxclient.client import DATA_NODE_HOST
+from nlpsandboxclient import utils
 
 
 # Command Group
 @click.group(name='community', no_args_is_help=True)
 def cli():
-    """Community related commands"""
+    """Commands for NLP Sandbox users"""
 
 
 @cli.command()
@@ -19,176 +16,6 @@ def get_num_users():
     syn = utils.synapse_login()
     res = syn.restGET("/teamMembers/count/3413388")
     print(f"Number of NLP sandbox users: {res['count']}")
-
-
-@cli.command(no_args_is_help=True)
-@click.option('--output', help='Output json filepath', type=click.Path())
-@click.option('--data_node_host', help='Data node host',
-              default=DATA_NODE_HOST, show_default=True)
-@click.option('--dataset_id', help='Dataset id', required=True)
-@click.option('--fhir_store_id', help='Dataset id', required=True)
-def list_notes(output, data_node_host, dataset_id, fhir_store_id):
-    """Gets clinical notes of a NLP data node FHIR store."""
-    clinical_notes = client.list_notes(host=data_node_host,
-                                       dataset_id=dataset_id,
-                                       fhir_store_id=fhir_store_id)
-    # Stdout or store to json
-    utils.stdout_or_json(list(clinical_notes), output)
-
-
-@cli.command(no_args_is_help=True)
-@click.option('--data_node_host', help='Data node host',
-              default=DATA_NODE_HOST, show_default=True)
-@click.option('--dataset_id', help='Dataset id')
-@click.option('--annotation_store_id', help='Annotation store id',
-              required=True)
-@click.option('--annotation_json', help='Json file with annotations to store',
-              type=click.Path(exists=True), required=True)
-def store_annotations(data_node_host, dataset_id, annotation_store_id,
-                      annotation_json):
-    """Store annotations in an NLP data node annotation store.
-    The annotation store is deleted if it already exists.
-    Sets the annotation_id as the note id.
-    """
-    with open(annotation_json, "r") as annot_f:
-        annotations = json.load(annot_f)
-    # If only one annotation is passed in, turn it into a list
-    if isinstance(annotations, dict):
-        annotations = [annotations]
-    client.store_annotations(
-        host=data_node_host,
-        dataset_id=dataset_id,
-        annotation_store_id=annotation_store_id,
-        annotations=annotations
-    )
-
-
-@cli.command(no_args_is_help=True)
-@click.option('--data_node_host', help='Data node host',
-              default=DATA_NODE_HOST, show_default=True)
-@click.option('--dataset_id', help='Dataset id', required=True)
-@click.option('--annotation_store_id', help='Dataset id', required=True)
-@click.option('--create_if_missing', help='Create resource if missing', is_flag=True)
-def get_annotation_store(data_node_host, dataset_id, annotation_store_id, create_if_missing):
-    """Create annotation store for a NLP data node dataset."""
-    # Create annotation store object
-    annotation_store = client.get_annotation_store(
-        host=data_node_host, dataset_id=dataset_id,
-        annotation_store_id=annotation_store_id,
-        create_if_missing=create_if_missing
-    )
-    print(annotation_store.name)
-
-
-@cli.command(no_args_is_help=True)
-@click.option('--data_node_host', help='Data node host',
-              default=DATA_NODE_HOST, show_default=True)
-@click.option('--dataset_id', help='Dataset Id', required=True)
-@click.option('--annotation_store_id', help='Dataset Id', required=True)
-@click.option('--annotation_id', help='Annotation Id', required=True)
-@click.option('--output', help='Output json filepath', type=click.Path())
-def get_annotation(data_node_host, dataset_id, annotation_store_id,
-                   annotation_id, output):
-    """Get annotation for a NLP data node dataset."""
-    annotation = client.get_annotation(
-        host=data_node_host, dataset_id=dataset_id,
-        annotation_store_id=annotation_store_id,
-        annotation_id=annotation_id
-    )
-    utils.stdout_or_json(annotation.to_dict(), output)
-
-
-@cli.command(no_args_is_help=True)
-@click.option('--data_node_host', help='Data node host',
-              default=DATA_NODE_HOST, show_default=True)
-@click.option('--dataset_id', help='Dataset id', required=True)
-@click.option('--annotation_store_id', help='Dataset id', required=True)
-@click.option('--output', help='Output json filepath', type=click.Path())
-def list_annotations(data_node_host, dataset_id, annotation_store_id, output):
-    """List annotations of a NLP data node annotation store."""
-    # Create annotation store object
-    annotations = client.list_annotations(
-        host=data_node_host, dataset_id=dataset_id,
-        annotation_store_id=annotation_store_id
-    )
-    utils.stdout_or_json(list(annotations), output)
-
-
-@cli.command()
-@click.option('--data_node_host', help='Data node host',
-              default=DATA_NODE_HOST, show_default=True)
-@click.option('--output', help='Output json filepath', type=click.Path())
-def list_datasets(data_node_host, output):
-    """List annotations of a NLP data node annotation store."""
-    # Create annotation store object
-    datasets = client.list_datasets(
-        host=data_node_host
-    )
-    utils.stdout_or_json(list(datasets), output)
-
-
-@cli.command(no_args_is_help=True)
-@click.option('--data_node_host', help='Data node host',
-              default=DATA_NODE_HOST, show_default=True)
-@click.option('--dataset_id', help='Dataset id', required=True)
-@click.option('--output', help='Output json filepath', type=click.Path())
-def store_dataset(data_node_host, dataset_id, output):
-    """Create a dataset in the data node"""
-    # Create dataset
-    dataset = client.store_dataset(host=data_node_host,
-                                   dataset_id=dataset_id)
-    utils.stdout_or_json(dataset.to_dict(), output)
-
-
-@cli.command(no_args_is_help=True)
-@click.option('--data_node_host', help='Data node host',
-              default=DATA_NODE_HOST, show_default=True)
-@click.option('--dataset_id', help='Dataset id', required=True)
-def delete_dataset(data_node_host, dataset_id):
-    """Create a dataset in the data node"""
-    # Create dataset
-    client.delete_dataset(host=data_node_host,
-                          dataset_id=dataset_id)
-
-# @cli.command()
-# @click.argument('noteid', type=click.INT)
-# @click.option('--output', help='Output json filepath', type=click.Path())
-# @click.option('--data_node_host',
-#               help='Data node host.  If not specified, uses '
-#                    'http://0.0.0.0:8080/api/v1')
-# def get_clinical_note(noteid, output, data_node_host):
-#     """Gets clinical note of NOTEID"""
-#     data_node_host = (data_node_host if data_node_host is not None
-#                       else client.DATA_NODE_HOST)
-#     nlp = DataNodeClient(host=data_node_host)
-#     clinical_note = nlp.get_clinical_note(noteid)
-#     utils.stdout_or_json(clinical_note, output)
-
-
-# @cli.command()
-# @click.option('--data_node_host',
-#               help='Data node host.  If not specified, uses '
-#                    'http://0.0.0.0:8080/api/v1')
-# def get_health(data_node_host):
-#     """Gets health of the API"""
-#     data_node_host = (data_node_host if data_node_host is not None
-#                       else client.DATA_NODE_HOST)
-#     nlp = DataNodeClient(host=data_node_host)
-#     print(nlp.get_health())
-
-
-# @cli.command()
-# @click.option('--output', help='Output json filepath', type=click.Path())
-# @click.option('--data_node_host',
-#               help='Data node host.  If not specified, uses '
-#                    'http://0.0.0.0:8080/api/v1')
-# def get_dates(output, data_node_host):
-#     """Get all date annotations"""
-#     data_node_host = (data_node_host if data_node_host is not None
-#                       else client.DATA_NODE_HOST)
-#     nlp = DataNodeClient(host=data_node_host)
-#     dates = nlp.get_dates()
-#     utils.stdout_or_json(dates, output)
 
 
 if __name__ == '__main__':

--- a/nlpsandboxclient/cli/datanode_cli.py
+++ b/nlpsandboxclient/cli/datanode_cli.py
@@ -10,7 +10,7 @@ from nlpsandboxclient.client import DATA_NODE_HOST
 # Command Group
 @click.group(name='datanode', no_args_is_help=True)
 def cli():
-    """Commands to interact with NLP Data Node"""
+    """Commands to interact with NLP Data Node."""
 
 
 @cli.command(no_args_is_help=True)

--- a/nlpsandboxclient/cli/datanode_cli.py
+++ b/nlpsandboxclient/cli/datanode_cli.py
@@ -1,0 +1,183 @@
+"""Data node CLI"""
+import json
+
+import click
+
+from nlpsandboxclient import client, utils
+from nlpsandboxclient.client import DATA_NODE_HOST
+
+
+# Command Group
+@click.group(name='datanode', no_args_is_help=True)
+def cli():
+    """Commands to interact with NLP Data Node"""
+
+
+@cli.command(no_args_is_help=True)
+@click.option('--output', help='Output json filepath', type=click.Path())
+@click.option('--data_node_host', help='Data node host',
+              default=DATA_NODE_HOST, show_default=True)
+@click.option('--dataset_id', help='Dataset id', required=True)
+@click.option('--fhir_store_id', help='Dataset id', required=True)
+def list_notes(output, data_node_host, dataset_id, fhir_store_id):
+    """Gets clinical notes of a NLP data node FHIR store."""
+    clinical_notes = client.list_notes(host=data_node_host,
+                                       dataset_id=dataset_id,
+                                       fhir_store_id=fhir_store_id)
+    # Stdout or store to json
+    utils.stdout_or_json(list(clinical_notes), output)
+
+
+@cli.command(no_args_is_help=True)
+@click.option('--data_node_host', help='Data node host',
+              default=DATA_NODE_HOST, show_default=True)
+@click.option('--dataset_id', help='Dataset id')
+@click.option('--annotation_store_id', help='Annotation store id',
+              required=True)
+@click.option('--annotation_json', help='Json file with annotations to store',
+              type=click.Path(exists=True), required=True)
+def store_annotations(data_node_host, dataset_id, annotation_store_id,
+                      annotation_json):
+    """Store annotations in an NLP data node annotation store.
+    The annotation store is deleted if it already exists.
+    Sets the annotation_id as the note id.
+    """
+    with open(annotation_json, "r") as annot_f:
+        annotations = json.load(annot_f)
+    # If only one annotation is passed in, turn it into a list
+    if isinstance(annotations, dict):
+        annotations = [annotations]
+    client.store_annotations(
+        host=data_node_host,
+        dataset_id=dataset_id,
+        annotation_store_id=annotation_store_id,
+        annotations=annotations
+    )
+
+
+@cli.command(no_args_is_help=True)
+@click.option('--data_node_host', help='Data node host',
+              default=DATA_NODE_HOST, show_default=True)
+@click.option('--dataset_id', help='Dataset id', required=True)
+@click.option('--annotation_store_id', help='Dataset id', required=True)
+@click.option('--create_if_missing', help='Create resource if missing', is_flag=True)
+def get_annotation_store(data_node_host, dataset_id, annotation_store_id, create_if_missing):
+    """Create annotation store for a NLP data node dataset."""
+    # Create annotation store object
+    annotation_store = client.get_annotation_store(
+        host=data_node_host, dataset_id=dataset_id,
+        annotation_store_id=annotation_store_id,
+        create_if_missing=create_if_missing
+    )
+    print(annotation_store.name)
+
+
+@cli.command(no_args_is_help=True)
+@click.option('--data_node_host', help='Data node host',
+              default=DATA_NODE_HOST, show_default=True)
+@click.option('--dataset_id', help='Dataset Id', required=True)
+@click.option('--annotation_store_id', help='Dataset Id', required=True)
+@click.option('--annotation_id', help='Annotation Id', required=True)
+@click.option('--output', help='Output json filepath', type=click.Path())
+def get_annotation(data_node_host, dataset_id, annotation_store_id,
+                   annotation_id, output):
+    """Get annotation for a NLP data node dataset."""
+    annotation = client.get_annotation(
+        host=data_node_host, dataset_id=dataset_id,
+        annotation_store_id=annotation_store_id,
+        annotation_id=annotation_id
+    )
+    utils.stdout_or_json(annotation.to_dict(), output)
+
+
+@cli.command(no_args_is_help=True)
+@click.option('--data_node_host', help='Data node host',
+              default=DATA_NODE_HOST, show_default=True)
+@click.option('--dataset_id', help='Dataset id', required=True)
+@click.option('--annotation_store_id', help='Dataset id', required=True)
+@click.option('--output', help='Output json filepath', type=click.Path())
+def list_annotations(data_node_host, dataset_id, annotation_store_id, output):
+    """List annotations of a NLP data node annotation store."""
+    # Create annotation store object
+    annotations = client.list_annotations(
+        host=data_node_host, dataset_id=dataset_id,
+        annotation_store_id=annotation_store_id
+    )
+    utils.stdout_or_json(list(annotations), output)
+
+
+@cli.command()
+@click.option('--data_node_host', help='Data node host',
+              default=DATA_NODE_HOST, show_default=True)
+@click.option('--output', help='Output json filepath', type=click.Path())
+def list_datasets(data_node_host, output):
+    """List annotations of a NLP data node annotation store."""
+    # Create annotation store object
+    datasets = client.list_datasets(
+        host=data_node_host
+    )
+    utils.stdout_or_json(list(datasets), output)
+
+
+@cli.command(no_args_is_help=True)
+@click.option('--data_node_host', help='Data node host',
+              default=DATA_NODE_HOST, show_default=True)
+@click.option('--dataset_id', help='Dataset id', required=True)
+@click.option('--output', help='Output json filepath', type=click.Path())
+def store_dataset(data_node_host, dataset_id, output):
+    """Create a dataset in the data node"""
+    # Create dataset
+    dataset = client.store_dataset(host=data_node_host,
+                                   dataset_id=dataset_id)
+    utils.stdout_or_json(dataset.to_dict(), output)
+
+
+@cli.command(no_args_is_help=True)
+@click.option('--data_node_host', help='Data node host',
+              default=DATA_NODE_HOST, show_default=True)
+@click.option('--dataset_id', help='Dataset id', required=True)
+def delete_dataset(data_node_host, dataset_id):
+    """Create a dataset in the data node"""
+    # Create dataset
+    client.delete_dataset(host=data_node_host,
+                          dataset_id=dataset_id)
+
+# @cli.command()
+# @click.argument('noteid', type=click.INT)
+# @click.option('--output', help='Output json filepath', type=click.Path())
+# @click.option('--data_node_host',
+#               help='Data node host.  If not specified, uses '
+#                    'http://0.0.0.0:8080/api/v1')
+# def get_clinical_note(noteid, output, data_node_host):
+#     """Gets clinical note of NOTEID"""
+#     data_node_host = (data_node_host if data_node_host is not None
+#                       else client.DATA_NODE_HOST)
+#     nlp = DataNodeClient(host=data_node_host)
+#     clinical_note = nlp.get_clinical_note(noteid)
+#     utils.stdout_or_json(clinical_note, output)
+
+
+# @cli.command()
+# @click.option('--data_node_host',
+#               help='Data node host.  If not specified, uses '
+#                    'http://0.0.0.0:8080/api/v1')
+# def get_health(data_node_host):
+#     """Gets health of the API"""
+#     data_node_host = (data_node_host if data_node_host is not None
+#                       else client.DATA_NODE_HOST)
+#     nlp = DataNodeClient(host=data_node_host)
+#     print(nlp.get_health())
+
+
+# @cli.command()
+# @click.option('--output', help='Output json filepath', type=click.Path())
+# @click.option('--data_node_host',
+#               help='Data node host.  If not specified, uses '
+#                    'http://0.0.0.0:8080/api/v1')
+# def get_dates(output, data_node_host):
+#     """Get all date annotations"""
+#     data_node_host = (data_node_host if data_node_host is not None
+#                       else client.DATA_NODE_HOST)
+#     nlp = DataNodeClient(host=data_node_host)
+#     dates = nlp.get_dates()
+#     utils.stdout_or_json(dates, output)

--- a/nlpsandboxclient/cli/evaluate.py
+++ b/nlpsandboxclient/cli/evaluate.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python3
-import json
-
 import click
-from nlpsandboxclient import client, evaluation, utils
+
+from nlpsandboxclient import evaluation, utils
 
 
 @click.group(name='evaluate', no_args_is_help=True)
@@ -10,7 +9,7 @@ def cli():
     """Evaluation related commands"""
 
 
-@cli.command(name="prediction", no_args_is_help=True)
+@cli.command(name="evaluate-prediction", no_args_is_help=True)
 @click.option('--pred_filepath', help='Prediction filepath',
               type=click.Path(exists=True), required=True)
 @click.option('--gold_filepath', help='Gold standard filepath',
@@ -35,51 +34,6 @@ def evaluate_prediction(pred_filepath, gold_filepath, output, eval_type):
     evaluator.convert_dict(pred_filepath, gold_filepath)
     results = evaluator.eval()
     utils.stdout_or_json(results, output)
-
-
-@cli.command(no_args_is_help=True)
-@click.option('--annotator_host', help='Annotator host.', required=True)
-@click.option('--note_json', help='Clinical notes json',
-              type=click.Path(exists=True), required=True)
-@click.option('--output', help='Specify output json path',
-              type=click.Path())
-@click.option('--annotator_type', help='Type of annotator.',
-              type=click.Choice(['date', 'person', 'address'],
-                                case_sensitive=False), required=True)
-def annotate_note(annotator_host, note_json, output, annotator_type):
-    """Annotate a note with specified annotator"""
-    with open(note_json, "r") as note_f:
-        notes = json.load(note_f)
-    all_annotations = []
-    for note in notes:
-        note_name = note.pop("note_name")
-        annotations = client.annotate_note(host=annotator_host,
-                                           note={"note": note},
-                                           annotator_type=annotator_type)
-        annotations['annotationSource'] = {
-            "resourceSource": {
-                "name": note_name
-            }
-        }
-        all_annotations.append(annotations)
-    utils.stdout_or_json(all_annotations, output)
-
-
-@cli.command(no_args_is_help=True)
-@click.option('--annotator_host', help='Annotator host', required=True)
-@click.option('--output', help='Specify output json path',
-              type=click.Path())
-def get_tool(annotator_host, output):
-    """Get annotator tool endpoint"""
-    tool = client.get_tool(host=annotator_host)
-    utils.stdout_or_json(tool.to_dict(), output)
-
-
-@cli.command(no_args_is_help=True)
-@click.option('--url', help='The url to check', required=True)
-def check_url(url):
-    """Checks if URL is implemented"""
-    utils.check_url(url=url)
 
 
 if __name__ == '__main__':

--- a/nlpsandboxclient/cli/tool.py
+++ b/nlpsandboxclient/cli/tool.py
@@ -43,7 +43,7 @@ def annotate_note(annotator_host, note_json, output, annotator_type):
 @click.option('--output', help='Specify output json path',
               type=click.Path())
 def get_tool(annotator_host, output):
-    """Get annotator tool endpoint"""
+    """Get tool information"""
     tool = client.get_tool(host=annotator_host)
     utils.stdout_or_json(tool.to_dict(), output)
 

--- a/nlpsandboxclient/cli/tool.py
+++ b/nlpsandboxclient/cli/tool.py
@@ -5,7 +5,7 @@ import click
 from nlpsandboxclient import client, utils
 
 
-@click.group(name='annotator', no_args_is_help=True)
+@click.group(name='tool', no_args_is_help=True)
 def cli():
     """Commands to interact with NLP annotators."""
 

--- a/nlpsandboxclient/cli/tool.py
+++ b/nlpsandboxclient/cli/tool.py
@@ -7,7 +7,7 @@ from nlpsandboxclient import client, utils
 
 @click.group(name='tool', no_args_is_help=True)
 def cli():
-    """Commands to interact with NLP annotators."""
+    """Commands to interact with NLP Tools."""
 
 
 @cli.command(no_args_is_help=True)


### PR DESCRIPTION
New cli: Fixes #127
```
Usage: nlp-cli [OPTIONS] COMMAND [ARGS]...

  NLP Sandbox Client

Options:
  --version  Show the version and exit.
  --help     Show this message and exit.

Commands:
  annotator            Commands to interact with NLP annotators.
  community            Commands for NLP Sandbox users.
  datanode             Commands to interact with NLP Data Node.
  evaluate-prediction  Evaluate the performance of a prediction file.
```

Also I just added `evaluate-prediction` as a command because there was only one command under "evaluate"

Note: A reason why the python code is named `datanode_cli.py` and `annotator_cli.py` is because the SDK packages are named `datanode` and `annotator`, so it would be redundant naming to have modules also named `datanode.py` and `annotator.py`.