### PR TITLE
Test client for Python 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,7 @@ setuptools.setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Operating System :: OS Independent',
         'Intended Audience :: Developers',
         'Intended Audience :: Science/Research',


### PR DESCRIPTION
Now that Synapse Python Client support Python 3.9, we should be able to test Python 3.9 here too.

https://github.com/Sage-Bionetworks/synapsePythonClient/blob/9aed0507de2ed58e4fd3fec80059a993bce925ae/setup.py#L10-L13