### PR TITLE
Support scoring for schemas 1.2.0

### DIFF
--- a/nlpsandboxclient/cli/evaluate.py
+++ b/nlpsandboxclient/cli/evaluate.py
@@ -19,7 +19,7 @@ def cli():
 @click.option('--tool_type', help='The type of tool to evaluate.',
               type=click.Choice(['nlpsandbox:date-annotator',
                                  'nlpsandbox:person-name-annotator',
-                                 'nlpsandbox:physical-address-annotator',
+                                 'nlpsandbox:location-annotator',
                                  'nlpsandbox:id-annotator',
                                  'nlpsandbox:contact-annotator'],
                                 case_sensitive=False), required=True)
@@ -31,7 +31,7 @@ def evaluate_prediction(pred_filepath, gold_filepath, output, tool_type):
     eval_mapping = {
         "nlpsandbox:date-annotator": evaluation.DateEvaluation,
         "nlpsandbox:person-name-annotator": evaluation.PersonNameEvaluation,
-        "nlpsandbox:physical-address-annotator": evaluation.PhysicalAddressEvaluation,
+        "nlpsandbox:location-annotator": evaluation.LocationEvaluation,
         'nlpsandbox:id-annotator': evaluation.IdEvaluation,
         'nlpsandbox:contact-annotator': evaluation.ContactEvaluation
     }

--- a/nlpsandboxclient/evaluation.py
+++ b/nlpsandboxclient/evaluation.py
@@ -265,11 +265,11 @@ class PersonNameEvaluation(Evaluation):
     post_path = "textPersonNameAnnotations"
 
 
-class PhysicalAddressEvaluation(Evaluation):
-    evaluation_type = "address"
-    annotation = "addressType"
-    col = "physical_location_annotations"
-    post_path = "textPhysicalAddressAnnotations"
+class LocationEvaluation(Evaluation):
+    evaluation_type = "location"
+    annotation = "locationType"
+    col = "location_annotations"
+    post_path = "textLocationAnnotations"
 
 
 class IdEvaluation(Evaluation):

--- a/test/client/test_evaluation.py
+++ b/test/client/test_evaluation.py
@@ -73,7 +73,7 @@ class TestEvaluation:
     def test_address(self):
         """Test person evaluation"""
         expected_results = {
-            'address_location': [
+            'location_location': [
                 {'metric': 'F1', 'value': 0.75, 'type': 'instance', 'mode': 'relax'},
                 {'metric': 'precision', 'value': 0.75, 'type': 'instance', 'mode': 'relax'},
                 {'metric': 'recall', 'value': 0.75, 'type': 'instance', 'mode': 'relax'},
@@ -84,13 +84,13 @@ class TestEvaluation:
                 {'metric': 'precision', 'value': 0.75, 'type': 'token', 'mode': 'strict'},
                 {'metric': 'recall', 'value': 0.6, 'type': 'token', 'mode': 'strict'}
             ],
-            'address_type': [
+            'location_type': [
                 {'metric': 'F1', 'value': 0.5},
                 {'metric': 'precision', 'value': 0.5},
                 {'metric': 'recall', 'value': 0.5}
             ]
         }
-        evaluator = evaluation.PhysicalAddressEvaluation()
+        evaluator = evaluation.LocationEvaluation()
         evaluator.convert_dict(self.pred_filepath, self.gold_filepath)
         results = evaluator.eval()
         assert results == expected_results

--- a/test/data/goldstandard.json
+++ b/test/data/goldstandard.json
@@ -24,13 +24,13 @@
                 "personType": "doctor"
             }
         ],
-        "textPhysicalAddressAnnotations": [
+        "textLocationAnnotations": [
             {
                 "start": 40,
                 "length": 7,
                 "text": "Seattle",
                 "confidence": 100,
-                "addressType": "city"
+                "locationType": "city"
             }
         ],
         "textIdAnnotations": [],
@@ -60,13 +60,13 @@
                 "personType": "patient"
             }
         ],
-        "textPhysicalAddressAnnotations": [
+        "textLocationAnnotations": [
             {
                 "start": 98,
                 "length": 2,
                 "text": "WA",
                 "confidence": 100,
-                "addressType": "state"
+                "locationType": "state"
             }
         ],
         "textIdAnnotations": [],
@@ -96,7 +96,7 @@
                 "personType": "patient"
             }
         ],
-        "textPhysicalAddressAnnotations": [],
+        "textLocationAnnotations": [],
         "textIdAnnotations": [],
         "textContactAnnotations": []
     }, {
@@ -124,13 +124,13 @@
                 "personType": "doctor"
             }
         ],
-        "textPhysicalAddressAnnotations": [
+        "textLocationAnnotations": [
             {
                 "start": 22,
                 "length": 11,
                 "text": "UW medicine",
                 "confidence": 100,
-                "addressType": "hospitalization"
+                "locationType": "hospitalization"
             }
         ],
         "textIdAnnotations": [],
@@ -144,13 +144,13 @@
         "name": "name",
         "textDateAnnotations": [],
         "textPersonNameAnnotations": [],
-        "textPhysicalAddressAnnotations": [
+        "textLocationAnnotations": [
             {
                 "start": 25,
                 "length": 7,
                 "text": "David's",
                 "confidence": 100,
-                "addressType": "organization"
+                "locationType": "organization"
             }
         ],
         "textIdAnnotations": [],
@@ -164,7 +164,7 @@
         "name": "name",
         "textDateAnnotations": [],
         "textPersonNameAnnotations": [],
-        "textPhysicalAddressAnnotations": [],
+        "textLocationAnnotations": [],
         "textIdAnnotations": [
             {
                 "start": 25,

--- a/test/data/prediction.json
+++ b/test/data/prediction.json
@@ -24,13 +24,13 @@
                 "personType": "doctor"
             }
         ],
-        "textPhysicalAddressAnnotations": [
+        "textLocationAnnotations": [
             {
                 "start": 40,
                 "length": 7,
                 "text": "Seattle",
                 "confidence": 95.5,
-                "addressType": "city"
+                "locationType": "city"
             }
         ],
         "textIdAnnotations": [],
@@ -60,13 +60,13 @@
                 "personType": "patient"
             }
         ],
-        "textPhysicalAddressAnnotations": [
+        "textLocationAnnotations": [
             {
                 "start": 98,
                 "length": 2,
                 "text": "WA",
                 "confidence": 95.5,
-                "addressType": "state"
+                "locationType": "state"
             }
         ],
         "textIdAnnotations": [],
@@ -96,7 +96,7 @@
                 "personType": "patient"
             }
         ],
-        "textPhysicalAddressAnnotations": [],
+        "textLocationAnnotations": [],
         "textIdAnnotations": [],
         "textContactAnnotations": []
     }, {
@@ -124,13 +124,13 @@
                 "personType": "patient"
             }
         ],
-        "textPhysicalAddressAnnotations": [
+        "textLocationAnnotations": [
             {
                 "start": 22,
                 "length": 2,
                 "text": "UW",
                 "confidence": 95.5,
-                "addressType": "organization"
+                "locationType": "organization"
             }
         ],
         "textIdAnnotations": [],
@@ -144,13 +144,13 @@
         "name": "name",
         "textDateAnnotations": [],
         "textPersonNameAnnotations": [],
-        "textPhysicalAddressAnnotations": [
+        "textLocationAnnotations": [
             {
                 "start": 25,
                 "length": 5,
                 "text": "David",
                 "confidence": 95.5,
-                "addressType": "organization"
+                "locationType": "organization"
             }
         ],
         "textIdAnnotations": [],
@@ -164,7 +164,7 @@
         "name": "name",
         "textDateAnnotations": [],
         "textPersonNameAnnotations": [],
-        "textPhysicalAddressAnnotations": [],
+        "textLocationAnnotations": [],
         "textIdAnnotations": [
             {
                 "start": 25,


### PR DESCRIPTION
Update scoring code to use `location` instead of `physical address`