### PR TITLE
Use npx to run the openapi-generator

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,11 +106,14 @@ the content of *setup.py* is updated.
 
 ### Updating the SDK client
 
-The Python SDK client `nlpsandbox` is now automatically updated when there is a new schemas release.  That being said, here are instructions on how to update the client manually.
+The Python SDK client `nlpsandbox` is now automatically updated when there is a
+new schemas release.  That being said, here are instructions on how to update
+the client manually.
 
-1. Generate SDK client with `openapi-generator`
-  ```
-  openapi-generator generate -g python -o . --package-name nlpsandbox -i https://nlpsandbox.github.io/nlpsandbox-schemas/_internal/nlpsandbox/edge/openapi.json
+1. Generate the SDK client with `openapi-generator`.
+
+  ```console
+  npx @openapitools/openapi-generator-cli generate -g python -o . --package-name nlpsandbox -i https://nlpsandbox.github.io/nlpsandbox-schemas/_internal/nlpsandbox/edge/openapi.json
   ```
 
 ### Testing

--- a/openapitools.json
+++ b/openapitools.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "node_modules/@openapitools/openapi-generator-cli/config.schema.json",
+  "spaces": 2,
+  "generator-cli": {
+    "version": "5.3.0"
+  }
+}


### PR DESCRIPTION
Update the contribution guide to suggest the use of `npx` to run `openapi-generator-cli` instead of assuming it to be already installed. Also prevent installing it globally.

Future improvement: Add a `package.json` and add openapi-generator as a script like we do for the data node and PHI tools.